### PR TITLE
Ok

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -11,6 +11,7 @@
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/background_mbti_select.xml" value="0.147" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/background_mbti_selector.xml" value="0.1625" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/background_mbti_unchecked.xml" value="0.1625" />
+        <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/background_not_yet.xml" value="0.1" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/background_sign_up_box.xml" value="0.213" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/button_login_background.xml" value="0.147" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/button_purple_background.xml" value="0.213" />
@@ -18,47 +19,19 @@
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/button_white_purple_background.xml" value="0.213" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/ic_launcher_background.xml" value="0.147" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/drawable/login_button_background.xml" value="0.147" />
+        <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_find_id_change_pw.xml" value="0.1703125" />
+        <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_find_id_finish_change_pw.xml" value="0.1703125" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_first.xml" value="0.19610507246376813" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_login.xml" value="0.165" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_main.xml" value="0.19610507246376813" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_sign_up.xml" value="0.165" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_start_mbtm.xml" value="0.25" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_blank.xml" value="0.24322916666666666" />
+        <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_find_id_change_pw.xml" value="0.1703125" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_sign_up_finish.xml" value="0.165" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_sign_up_first.xml" value="0.19479166666666667" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_sign_up_mbti.xml" value="0.16770833333333332" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_sign_up_second.xml" value="0.16666666666666666" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.1205" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/drawable/background_home.xml" value="0.17" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/drawable/background_login_box.xml" value="0.1" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/drawable/background_not_yet.xml" value="0.1885" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/drawable/button_login_background.xml" value="0.1" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/drawable/button_signup_background.xml" value="0.1" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/drawable/ic_launcher_background.xml" value="0.1205" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout-w1240dp/activity_find_id_finish2.xml" value="0.16030789825970548" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout-w936dp/activity_find_id_finish2.xml" value="0.187109375" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_change_pw.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_id_change_pw.xml" value="0.264" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_id_change_pw_temp.xml" value="0.109375" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_id_finish.xml" value="0.264" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_id_finish2.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_id_finish_change_pw.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_id_input.xml" value="0.264" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_id_password_id_change.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_pw_change_pw.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_pw_enter_code.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_find_pw_get_code.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_finish_change_pw.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_first.xml" value="0.264" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_home.xml" value="0.24947916666666667" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_login.xml" value="0.264" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_main.xml" value="0.2" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/activity_temp.xml" value="0.2453125" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/fragment_find_id_change_pw.xml" value="0.23233695652173914" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/fragment_find_id_finish.xml" value="0.23233695652173914" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/layout/fragment_find_id_input.xml" value="0.2" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" value="0.1" />
-        <entry key="..\:/Users/sgb12/Desktop/MBTM_Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml" value="0.1215" />
       </map>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -26,8 +26,10 @@
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_main.xml" value="0.19610507246376813" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_sign_up.xml" value="0.165" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_start_mbtm.xml" value="0.25" />
+        <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/activity_test.xml" value="0.1" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_blank.xml" value="0.24322916666666666" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_find_id_change_pw.xml" value="0.1703125" />
+        <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_find_id_input.xml" value="0.1703125" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_sign_up_finish.xml" value="0.165" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_sign_up_first.xml" value="0.19479166666666667" />
         <entry key="..\:/Users/kosaf888/AndroidStudioProjects/MBTM/app/src/main/res/layout/fragment_sign_up_mbti.xml" value="0.16770833333333332" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,20 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.mbtm">
+    package="com.example.mbtm" >
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:usesCleartextTraffic="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MBTM"
-        tools:targetApi="31">
+        tools:targetApi="31" >
+        <activity
+            android:name=".TestActivity"
+            android:exported="false" />
         <activity
             android:name=".HomeActivity"
             android:exported="false" />
@@ -53,8 +57,7 @@
             android:exported="false" />
         <activity
             android:name=".MainActivity"
-            android:exported="true">
-
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/mbtm/AuthResponse.kt
+++ b/app/src/main/java/com/example/mbtm/AuthResponse.kt
@@ -11,9 +11,6 @@ data class AuthResponse(
 
 data class Result(
     @SerializedName(value = "userIdx") var userIdx: Int,
-
     @SerializedName(value = "id") var id: String,
-
-
     @SerializedName(value = "jwt") var jwt: String
 )

--- a/app/src/main/java/com/example/mbtm/SignUpMbtiFragment.kt
+++ b/app/src/main/java/com/example/mbtm/SignUpMbtiFragment.kt
@@ -1,9 +1,9 @@
 package com.example.mbtm
 
+import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
-import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -11,6 +11,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.Toast
+import android.widget.Toast.LENGTH_SHORT
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
@@ -18,7 +20,7 @@ import com.example.mbtm.databinding.FragmentSignUpMbtiBinding
 import com.example.mbtm.gridRadioGroup.OnCheckedChangeListener
 
 
-class SignUpMbtiFragment : Fragment(), SignUpView  {
+class SignUpMbtiFragment : Fragment(), SignUpView {
 
     val mbtiArray = arrayOf(
         "ISTJ", "ISFJ", "INFJ", "INTJ", "ISTP", "ISFP",
@@ -36,6 +38,18 @@ class SignUpMbtiFragment : Fragment(), SignUpView  {
     lateinit var navController: NavController
     lateinit var binding: FragmentSignUpMbtiBinding
     lateinit var prev: String
+    private val activityResultLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == RESULT_OK) {
+                val mbti = it.data?.getStringExtra("mbti")
+                if (mbti in mbtiArray) {
+                    signUpMbti(mbti!!)
+                } else {
+                    Toast.makeText(activity, "결과가 옳지 않습니다", LENGTH_SHORT).show()
+                }
+            }
+        }
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
@@ -59,6 +73,23 @@ class SignUpMbtiFragment : Fragment(), SignUpView  {
             }
         })
 
+
+        val args = arguments
+        if (args != null) return
+
+
+        binding.startTestBtn.setOnClickListener {
+            getMbti()
+        }
+
+    }
+
+    private fun getMbti() {
+        val intent = Intent(activity, TestActivity::class.java)
+        val bundle = Bundle()
+        bundle.putString("Url", "https://www.16personalities.com/ko/")
+        intent.putExtras(bundle)
+        activityResultLauncher.launch(intent)
     }
 
 
@@ -78,13 +109,18 @@ class SignUpMbtiFragment : Fragment(), SignUpView  {
                 signUpMbti(userMbti)
             }
         }
-        binding.startTestBtn.setOnClickListener {
-            val i = Intent(Intent.ACTION_VIEW)
-            i.data = Uri.parse("https://www.16personalities.com/ko/")
-            startActivity(i)
-        }
 
         return binding.root
+    }
+
+    override fun onPause() {
+        super.onPause()
+        Toast.makeText(activity, "프래그먼트 onPause", LENGTH_SHORT).show()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        Toast.makeText(activity, "프래그먼트 onResume", LENGTH_SHORT).show()
     }
 
     private fun signUpMbti(userMbti: String) {
@@ -110,7 +146,7 @@ class SignUpMbtiFragment : Fragment(), SignUpView  {
     }
 
     override fun onSignUpSuccess(code: Int, result: Result) {
-        when(code) {
+        when (code) {
             1000 -> {
                 Toast.makeText(activity, "mbti 입력에 성공하였습니다", Toast.LENGTH_SHORT).show()
                 navController.navigate(R.id.action_mbtiFragment_to_finishFragment)

--- a/app/src/main/java/com/example/mbtm/TestActivity.kt
+++ b/app/src/main/java/com/example/mbtm/TestActivity.kt
@@ -1,0 +1,67 @@
+package com.example.mbtm
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+import com.example.mbtm.databinding.ActivityTestBinding
+
+
+class TestActivity : AppCompatActivity() {
+
+    lateinit var binding: ActivityTestBinding
+    lateinit var webView: WebView
+    lateinit var mbti: String
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTestBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        initWebView()
+
+        binding.testSaveBtn.setOnClickListener {
+            saveMbti()
+
+            val intent = Intent()
+            intent.putExtra("mbti", mbti)
+            setResult(RESULT_OK, intent)
+            finish()
+        }
+    }
+
+    private fun saveMbti() {
+        var url: String = webView.url.toString()
+        mbti = url.substring(url.length - 4).uppercase()
+        binding.testSaveBtn.text = mbti
+        Log.d("OKOK/TEST/", mbti)
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun initWebView() {
+
+        Log.d("OKOK/TEST/", "initWebView1")
+
+        val intent = intent
+        val bundle = intent.extras
+        val testValue = bundle!!.getString("Url")
+
+        webView = findViewById<WebView>(R.id.test_wv)
+
+        binding.testTv.text = testValue
+
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            setSupportMultipleWindows(true)
+        }
+
+        webView.webViewClient = WebViewClient()
+        webView.loadUrl(testValue!!)
+        Log.d("OKOK/TEST/", "initWebView2")
+    }
+
+
+}

--- a/app/src/main/res/layout/activity_test.xml
+++ b/app/src/main/res/layout/activity_test.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TestActivity">
+
+    <TextView
+        android:id="@+id/test_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="dd"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+    <WebView
+        android:id="@+id/test_wv"
+        android:layout_width="match_parent"
+        android:layout_height="650dp"
+        app:layout_constraintTop_toBottomOf="@id/test_tv"/>
+
+    <Button
+        android:id="@+id/test_save_btn"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:text="저장"
+        app:layout_constraintBottom_toBottomOf="@id/test_wv"
+        app:layout_constraintEnd_toEndOf="@id/test_wv"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### 제목
Webview 로 가져온 Mbti Test 결과 저장 & API 연결

### 작업내용
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 기타 설정

### 수정내용

- 기존에는 회원 가입 과정 중 MBTI 기입하는 fragment 에서 'MBTI를 아직 몰라요'를 클릭하면 앱 외부 브라우저로 검사 창이 뜨도록 함

> fragment 에서 'MBTI를 아직 몰라요'를 클릭 시 TestActivity 를 띄움, Webview 를 이용하여 앱 내 테스트 화면 출력
저장 버튼 클릭 시 Activity 종료와 동시에  회원가입 fragment 에 결괏값 전달
전달된 MBTI 값이 유효하다면 회원가입 진행


### 주의 사항

1. Test Activity 디자인 반영 안 됨
2. mbti 유효성 검사를 `SignUpMbtiFragment.kt` 에서 함